### PR TITLE
HFIX: Workaround wardriver being in beta.

### DIFF
--- a/data/firmwareRepositories.csv
+++ b/data/firmwareRepositories.csv
@@ -1,3 +1,3 @@
 NAME,DESC,VER,LINK,EMOJI,RELID,
 "ScriptKitty","Cat-Themed USB Attack Platform with WiFi Control","latest","https://github.com/DevKitty-io/ScriptKitty-Firmware",,135056446,
-"Wardriver","Scan & Map Wireless Devices! Compatible with WiGLE","latest","https://github.com/DevKitty-io/Wardriver-Firmware",,,
+"Wardriver","Scan & Map Wireless Devices! Compatible with WiGLE","v1.0-231225","https://github.com/DevKitty-io/Wardriver-Firmware",,,


### PR DESCRIPTION
* For now hardcode the tag release. Will come back back and actually fix it later.