### PR TITLE
HFIX: take two and actually fix this.

### DIFF
--- a/data/firmwareRepositories.csv
+++ b/data/firmwareRepositories.csv
@@ -1,3 +1,3 @@
 NAME,DESC,VER,LINK,EMOJI,RELID,
 "ScriptKitty","Cat-Themed USB Attack Platform with WiFi Control","latest","https://github.com/DevKitty-io/ScriptKitty-Firmware",,135056446,
-"Wardriver","Scan & Map Wireless Devices! Compatible with WiGLE","v1.0-231225","https://github.com/DevKitty-io/Wardriver-Firmware",,,
+"Wardriver","Scan & Map Wireless Devices! Compatible with WiGLE","v0.0-240817","https://github.com/DevKitty-io/Wardriver-Firmware",,170732534,

--- a/data/read.sh
+++ b/data/read.sh
@@ -23,6 +23,7 @@ while IFS=',' read -r NAME DESC VER LINK EMOJI RELID; do
 
 	if [ $counter -eq 0 ]; then
 		counter=$((counter + 1))
+		# echo "$NAME,$DESC,$VER,$LINK,$EMOJI,$RELID," >>"$temp_file"
 		echo "$NAME,$DESC,$VER,$LINK,$EMOJI,$RELID," >>"$temp_file"
 		continue
 	else
@@ -41,14 +42,28 @@ while IFS=',' read -r NAME DESC VER LINK EMOJI RELID; do
 	# NOTE: gets the last elem in string
 	repo=${LINK##*/}
 	repo=${repo::-1}
+	# ver=${VER:1:-1}
 	ver=${VER:1:-1}
-	# echo "$repo"
+  echo "$ver"
+	echo "$repo"
+  # echo "$tag"
+  if [[ $ver != "latest" ]]; then
+    # TODO get tag later using this api call
+    # URL="https://api.github.com/repos/DevKitty-io/${repo}/tags"
+  
+  # https://api.github.com/repos/DevKitty-io/Wardriver-Firmware/releases/tags/v0.0-240817
+    URL="https://api.github.com/repos/DevKitty-io/${repo}/releases/tags/${ver}"
+  else
+    URL="https://api.github.com/repos/DevKitty-io/${repo}/releases/${ver}"
+  fi
 	# const assetUrl = `https://api.github.com/repos/DevKitty-io/${text}/releases/latest`;
 	# curl -LO "$lline/"
 	#https://api.github.com/repositories/731907336/releases/latest
-	URL="https://api.github.com/repos/DevKitty-io/${repo}/releases/${ver}"
-	# echo "$URL"
-	list=$(curl "$URL")
+  # https://github.com/DevKitty-io/ScriptKitty-Firmware/releases/tag/
+  # https://api.github.com/repos/DevKitty-io/ScriptKitty-Firmware/tags
+  # URL=""https://api.github.com/repos/DevKitty-io/ScriptKitty-Firmware/zipball/refs/tags/v1.0-231225""
+  echo "$URL"
+  list=$(curl "$URL")
 	if [[ -z "$list" ]]; then
 		# echo "check=false" >> "$GITHUB_OUTPUT"
 		# TODO: figure how to get this check to clear so that the next check is not neededj


### PR DESCRIPTION
Actually fix not being able to pull assets from tags. For now, do not get the latest release if the csv does not specify getting the latest release. This makes it possible to lock to a stable releases, while allowing people to download pre-releases and upload their own.